### PR TITLE
remove csa_rescale_stat.py dependence on SCT

### DIFF
--- a/csa_rescale_stat.py
+++ b/csa_rescale_stat.py
@@ -27,7 +27,7 @@ from math import ceil
 
 def get_parser():
     parser = argparse.ArgumentParser(
-        description='Compute statistics based on the csv file containing the metrics:',
+        description='Compute statistics based on the csv files containing the CSA metrics:',
         add_help=None,
         formatter_class=argparse.RawTextHelpFormatter,
         prog=os.path.basename(__file__).strip(".py"))
@@ -37,21 +37,21 @@ def get_parser():
         "-i",
         required=True,
         default='results',
-        help='Input csv file path to results. (e.g. results)',
+        help='Input csv file path to results. (e.g. "results")',
     )
 
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         '-v',
-        type=int,
-        help='Verbose.',
-        required=False,
-        default=1,
-        choices=(0, 1),)
+        help='Verbose, plotting figures',
+        nargs="*"
+    )
+
     optional.add_argument(
         '-h',
-        required=False,
-        help=' help',)
+        help='Help',
+        nargs="*"
+    )
 
     return parser
 
@@ -151,8 +151,8 @@ def main():
     print('with 80% power, at 5% significance:')
     print('minimum sample size to detect mean 10% atrophy: ',n )
 
-    # plot graph if verbose is 1
-    if arguments.v == 1:
+    # plot graph if verbose is present
+    if arguments.v is not None:
         get_plot(atrophy, diff_arr)
         get_plot_sample(1.96,(0.84, 1.282), std, 80)
         print('\nfigures have been ploted in dataset')
@@ -164,6 +164,9 @@ if __name__ == "__main__":
     # get parser elements
     parser = get_parser()
     arguments = parser.parse_args(args=None if sys.argv[0:] else ['--help'])
-    path_results = os.path.join(os.getcwd(),arguments.i)
-    get_data(path_results)
-    main()
+    if arguments.h is None:
+        path_results = os.path.join(os.getcwd(),arguments.i)
+        get_data(path_results)
+        main()
+    else:
+        parser.print_help()

--- a/csa_rescale_stat.py
+++ b/csa_rescale_stat.py
@@ -11,41 +11,26 @@
 #########################################################################################
 from __future__ import division
 
-
+import pandas as pd
+import numpy as np
 import sys, os
 import argparse
-import numpy as np
-from numpy import genfromtxt
 from scipy import stats
-from spinalcordtoolbox.aggregate_slicewise import  save_as_csv # absence causes error ??
-import sct_utils as sct
-from spinalcordtoolbox.utils import Metavar, SmartFormatter
-
-
+import matplotlib
+import matplotlib.pyplot as plt
+from math import ceil
 
 
 # Parser
 #########################################################################################
+
 def get_parser():
     parser = argparse.ArgumentParser(
         description='Compute statistics based on the csv file containing metrics:',
         add_help=None,
-        formatter_class=SmartFormatter,
+        formatter_class=argparse.RawTextHelpFormatter,
         prog=os.path.basename(__file__).strip(".py"))
 
-    mandatory = parser.add_argument_group("\nMANDATORY ARGUMENTS")
-    mandatory.add_argument(
-        '-i',
-        required=True,
-        metavar=Metavar.file,
-        help=' metrics file csv',
-        )
-    mandatory.add_argument(
-        '-r',
-        required=True,
-        help=' metrics file csv for rescaled',
-        metavar=Metavar.file,
-        )
     optional = parser.add_argument_group("\nOPTIONAL ARGUMENTS")
     optional.add_argument(
         '-v',
@@ -54,35 +39,50 @@ def get_parser():
         required=False,
         default=1,
         choices=(0, 1),)
+    optional.add_argument(
+        '-h',
+        required=False,
+        help=' help',)
+
     return parser
 
 # Functions
 #########################################################################################
-# Computes mean of metric over all subjects
-def mean_metric(metrics, key):
-    mean_metric = np.mean(metrics[key])
-    return mean_metric
+    # data extraction for pandas
+def get_data():
+    files = []
+    for file in os.listdir("results"):
+        if file.endswith(".csv"):
+            files.append(os.path.join(os.getcwd(),'results/',file))
+    metrics = pd.concat([pd.read_csv(f).assign(rescale=os.path.basename(f).split('r_')[1].split('.csv')[0]) for f in files ])
+    metrics.to_csv("csa.csv")
 
-# Computes percentage difference between theoric and measured CSA rescaled
-# def per_dif_metric(metrics, metrics_r, key, atrophy):
-#    perc_diff_metric = 100*(abs(np.subtract(metrics_r[key],(atrophy*metrics[key]))))/(atrophy*metrics[key])
-#    return perc_diff_metric
+def get_plot(atrophy, diff_arr):
+    fig = plt.figure()
+    y_pos = np.arange(len(atrophy))
+    # plot
+    plt.bar(y_pos, diff_arr, align='center', alpha=0.5)
+    plt.xticks(y_pos, atrophy)
+    plt.xlabel('rescaling factor')
+    plt.title('error in function of rescaling factor')
+    plt.ylabel('error in %')
+    plt.grid()
+    fig.savefig("err_plot.jpg")
 
-# Computes standard deviation between theoric and measured CSA rescaled
-def std_metric(metrics):
-    var = np.mean(abs(metrics - np.mean(metrics))**2)
-    std_metric = np.sqrt(var)
-    return std_metric
 
-# computes pearson r between original and rescaled image
-# def pearsonr_metric(metrics, metrics_r, key):
-#    pearsonr_metric = stats.pearsonr(metrics_r[key], metrics[key])
-#    return pearsonr_metric
-
-# Computes t test for significance of difference
-def ttest_metric(metrics, metrics_r, key, atrophy):
-    metric_ttest,metric_pval = stats.ttest_ind(metrics[key]*atrophy,metrics_r[key])
-    return metric_ttest,metric_pval
+def get_plot_sample(z, z_power, std):
+    fig = plt.figure()
+    # data for plotting
+    i = np.arange(1.5, 8.0, 0.05)
+    num_n = ((z+z_power)**2)*((2*std)**2)
+    n = (num_n/((i)**2))
+    # plot
+    plt.plot(i, n)
+    plt.ylabel('minimum number of participants')
+    plt.xlabel('atrophy in mm^2')
+    plt.title('minimum number of subjects to detect an atrophy ')
+    plt.grid()
+    fig.savefig("min_subj.jpg")
 
 
 
@@ -90,54 +90,56 @@ def ttest_metric(metrics, metrics_r, key, atrophy):
 #########################################################################################
 def main():
     # get parser elements
-    arguments = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
-    # fname
-    fname = os.path.abspath(arguments.i)
-    fname_r = os.path.abspath(arguments.r)
+    arguments = parser.parse_args(args=None if sys.argv[0:] else ['--help'])
 
-    # data extraction for numpy
-    metrics_subj_o = genfromtxt(fname, delimiter=',', names=True, dtype=None, encoding='UTF-8')
-    metrics_subj_r = genfromtxt(fname_r, delimiter=',', names=True, dtype=None, encoding='UTF-8')
-    # metrics_perslice = genfromtxt(fname_perslice, delimiter=',', names=True, dtype=None, encoding='UTF-8')
-    # metrics_perslice_r = genfromtxt(fname_perslice_r, delimiter=',', names=True, dtype=None, encoding='UTF-8')
+    #read data
+    get_data()
+    data = pd.read_csv("csa.csv",decimal=".")
 
-    verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
-
+    #ground truth atrophy
+    atrophy = sorted(set(data['rescale']))
     # Computes mean of metric over all subjects
-    mean_CSA = mean_metric(metrics_subj_o, 'MEANarea')
-    mean_CSA_r = mean_metric(metrics_subj_r, 'MEANarea')
-    sct.printv('the mean CSA on all original slices is ' + str(mean_CSA) + ' mm^2\n', 'info')
-    sct.printv('the mean CSA fon all rescaled slices is ' + str(mean_CSA_r) + ' mm^2\n', 'info')
+    print("====================diff==========================\n")
+    diff_arr = []
+    for r in atrophy:
+        gt_CSA = float(data.groupby('rescale')['MEAN(area)'].get_group(1).mean())
+        r_CSA = data.groupby('rescale')['MEAN(area)'].get_group(r).mean()
+        diff_perc = 100*(r_CSA - gt_CSA*(r**(2/3)))/(gt_CSA*(r**(2/3)))
+        diff_arr.append(gt_CSA-r_CSA)
+        print('the difference with ground truth for ',r,' rescaling is ',diff_perc,' %')
 
     # Computes standard deviation between theoric and measured CSA rescaled
-    atrophy = (0.9) ** (2 / 3)
-    CSA_subj_o_r = metrics_subj_o['MEANarea']*atrophy
-    std_CSA = std_metric(CSA_subj_o_r)
-    std_CSA_r = std_metric(metrics_subj_r['MEANarea'] )
-    sct.printv('the std of CSA is ' + str(std_CSA) + ' mm^2\n', 'info')
-    sct.printv('the std of CSA rescaled is ' + str(std_CSA_r) + ' mm^2\n', 'info')
-
-    # computes pearson r between original and rescaled image
-    # pearsonr_CSA = pearsonr_metric(metrics_subj_o, metrics_subj_r, 'MEANarea')
-    # sct.printv('the pearson correlation coeff between original and rescaled image is ' + str(pearsonr_CSA) + '\n', 'info')
-
-    # Computes percentage difference between theoric and measured CSA rescaled
-    # perc_diff_CSA = per_dif_metric(metrics_subj_o, metrics_subj_r, 'MEANarea', atrophy)
-    # sct.printv('Percentage difference from theoric atrophy is ' + str(perc_diff_CSA) + ' %\n', 'info')
+    print("\n====================std==========================\n")
+    std_arr = []
+    for r in atrophy:
+        std = data.groupby('rescale')['MEAN(area)'].get_group(r).std()
+        print('CSA std on ',r,' rescaled image is ',float(std),' mm^2 ')
 
     # Computes t test for significance of difference
-    CSA_ttest,CSA_pval = ttest_metric(metrics_subj_o,metrics_subj_r, 'MEANarea', atrophy)
-    sct.printv('p-value for the rescale test is ' + str(CSA_pval) + ' \n', 'info')
+    print("\n====================ttest==========================\n")
+    for r in atrophy:
+        ttest,pvalue = stats.ttest_ind(data.groupby('rescale')['MEAN(area)'].get_group(r), data.groupby('rescale')['MEAN(area)'].get_group(1)*(r**(2/3)))
+        print('p-value for ',r,' rescaled image is ',pvalue,' ')
 
-    verbose = arguments.v
-    sct.init_sct(log_level=verbose, update=True)  # Update log level
+    # calculate the minimum number of patients required to detect an atrophy of X (i.e. power analysis)
+    print("\n====================size==========================\n")
+    # sample size with certainty 95% z(0.05)=1.645 power 0.8 zscore=1.282
+    num_n = ((1.645+1.282)**2)*((2*std)**2)
+    deno_n = (0.0178*80)**2
+    n = ceil(num_n/deno_n)
+    print('with 80% power, at 5% significance:')
+    print('minimum sample size to detect annual mean MS atrophy (',deno_n,'mm^2): ',n )
 
+    # plot grah if verbose is 2
+    if arguments.v == 1:
+        get_plot(atrophy, diff_arr)
+        get_plot_sample(1.645, 1.282, std)
+        print('\nfigures have been ploted in dataset')
 
 
 # Run
 #########################################################################################
 if __name__ == "__main__":
-    sct.init_sct()
+#    sct.init_sct()
     parser = get_parser()
     main()


### PR DESCRIPTION
- `csa_rescale_stat.py` was dependent on SCT and did not support the multiple resampling values. 
- csv files were read with numpy; The new python script looks for all csv outputs, aggregate them into a pandas DF, and then does the stats on this single DF.

DONE:
-remove csa_rescale_stat.py dependence on SCT
-add plots
-add sample size
-reading csv files with pandas and not numpy

TO DO:
-give reference for number of patients stat

Fix #6 