### PR TITLE
refactoring of affine transfo

### DIFF
--- a/affine_rescale.py
+++ b/affine_rescale.py
@@ -47,7 +47,14 @@ def get_parser():
 
 #MAIN
 ############################################################
-def main(fname, coef_r):
+def main():
+    # get parser elements
+    parser = get_parser()
+    arguments = parser.parse_args(args=None if sys.argv[0:] else ['--help'])
+    # create variables
+    fname = arguments.i
+    coef_r = arguments.r
+
     print(coef_r)
     # iterate transformation for each subject,
     img = nib.load(fname) # load image
@@ -62,9 +69,4 @@ def main(fname, coef_r):
 #RUN
 ############################################################
 if __name__ == "__main__":
-    # get parser elements
-    parser = get_parser()
-    arguments = parser.parse_args(args=None if sys.argv[0:] else ['--help'])
-    fname = arguments.i
-    coef_r = arguments.r
-    main(fname, coef_r)
+    main()

--- a/affine_transfo.py
+++ b/affine_transfo.py
@@ -51,7 +51,7 @@ def get_parser():
     )
     optional.add_argument(
         '-o',
-        help='Output filename extension to identify new file,\nexample: (input = t) sub-amu01_T2W.nii.gz ==> sub-amu01_T2w_t.nii.gz',
+        help="Suffix for output file name.\nexample: '-i MYFILE.nii -o _t' would output MYFILE_t.nii",
         default='_t',
     )
     optional.add_argument(
@@ -167,11 +167,13 @@ def transfo(angle_IS, angle_PA, angle_LR, shift_LR, shift_PA, shift_IS, data):
      return data_shift_rot
 
 
-def main(fname, fname_ext):
+def main(fname, suffix):
     """Main function, crop and save image"""
     name = os.path.basename(fname).split(fname)[0]
     path = os.path.join(os.getcwd(), fname) # get file path
-    path_tf = path.split('.nii.gz')[0] + '_'+str(fname_ext)+'.nii.gz' # create new path to save data
+    print(path.split('.nii.gz')[0])
+    path_tf = os.path.join(path, path.split('.nii.gz')[0]+str(suffix)+'.nii.gz')# create new path to save data
+    print(path_tf)
     if os.path.isfile(path_tf):
         os.remove(path_tf)
     img = nib.load(fname) # load image
@@ -193,12 +195,12 @@ if __name__ == "__main__":
     arguments = parser.parse_args(args=None if sys.argv[0:] else ['--help'])
     if arguments.h is None:
         for subject in arguments.i:
-            if os.path.isdir(arguments.p+'/'+subject):
-                path = glob.glob(arguments.p+'/'+str(subject)+'/anat/*T2w.nii.gz')
+            if os.path.isdir(arguments.p+'/'+subject): # verify presence of subject in dataset
+                path = glob.glob(arguments.p+'/'+str(subject)+'/anat/*T2w.nii.gz') # find subject in dataset
                 for fnames in path:
                     main(fnames, arguments.o)
             elif subject == 'all':
-                for fnames in glob.glob(arguments.p+'/*/*/*T2w.nii.gz'):
+                for fnames in glob.glob(arguments.p+'/*/*/*T2w.nii.gz'): # apply transformation on all subjects of dataset
                     main(fnames, arguments.o)
             else:
                 print('error: '+subject+' is not a valide subject')

--- a/affine_transfo.py
+++ b/affine_transfo.py
@@ -50,15 +50,14 @@ def get_parser():
         nargs="*"
     )
     optional.add_argument(
-        '-r',
-        help='Number of iterations of transformations on each subject',
-        type=int,
-        default=1,
+        '-o',
+        help='Output filename extension to identify new file,\nexample: (input = t) sub-amu01_T2W.nii.gz ==> sub-amu01_T2w_t.nii.gz',
+        default='_t',
     )
     optional.add_argument(
         '-p',
-        help='path to subject image directory',
-        default='data',
+        help='Path to subject image directory, default: ./data',
+        default= 'data',
     )
     return parser
 
@@ -168,11 +167,11 @@ def transfo(angle_IS, angle_PA, angle_LR, shift_LR, shift_PA, shift_IS, data):
      return data_shift_rot
 
 
-def main(fname, j):
+def main(fname, fname_ext):
     """Main function, crop and save image"""
     name = os.path.basename(fname).split(fname)[0]
     path = os.path.join(os.getcwd(), fname) # get file path
-    path_tf = path.split('.nii.gz')[0] + '-t'+str(j)+'.nii.gz' # create new path to save data
+    path_tf = path.split('.nii.gz')[0] + '_'+str(fname_ext)+'.nii.gz' # create new path to save data
     if os.path.isfile(path_tf):
         os.remove(path_tf)
     img = nib.load(fname) # load image
@@ -197,10 +196,10 @@ if __name__ == "__main__":
             if os.path.isdir(arguments.p+'/'+subject):
                 path = glob.glob(arguments.p+'/'+str(subject)+'/anat/*T2w.nii.gz')
                 for fnames in path:
-                    [main(fnames, j) for j in range(arguments.r)]
+                    main(fnames, arguments.o)
             elif subject == 'all':
                 for fnames in glob.glob(arguments.p+'/*/*/*T2w.nii.gz'):
-                    [main(fnames, j) for j in range(arguments.r)]
+                    main(fnames, arguments.o)
             else:
                 print('error: '+subject+' is not a valide subject')
     else:

--- a/affine_transfo.py
+++ b/affine_transfo.py
@@ -164,45 +164,48 @@ def transfo(angle_IS, angle_PA, angle_LR, shift_LR, shift_PA, shift_IS, data):
      return data_shift_rot
 
 
-def main(fname, suffix):
-    """Main function, crop and save image"""
-    name = os.path.basename(fname).split(fname)[0]
-    # get file path
-    path = os.path.join(os.getcwd(), fname)
-    # create new path to save data
-    path_tf = os.path.join(path, path.split('.nii.gz')[0]+str(suffix)+'.nii.gz')
-    if os.path.isfile(path_tf):
-        os.remove(path_tf)
-    # load image
-    print(fname)
-    img = nib.load(fname)
-    print('\n----------affine transformation subject: '+name+'------------')
-    angle_IS, angle_PA, angle_LR, shift_LR, shift_PA, shift_IS = random_values()
-    # nibabel data follows the RAS+ (Right, Anterior, Superior are in the ascending direction) convention,
-    data, min_pad = get_image(img, angle_IS, angle_PA, angle_LR, shift_LR, shift_PA, shift_IS)
-    data_shift_rot = transfo(angle_IS, angle_PA, angle_LR, shift_LR, shift_PA, shift_IS, data)
-    # load data back to nifti format
-    img_t = nib.Nifti1Image(data_shift_rot, img.affine)
-    print('new image shape: ',img_t.shape)
-    print('new image path: '+path_tf)
-    img_t.to_filename(path_tf)
-
-
-if __name__ == "__main__":
+def main():
     # get parser elements
     parser = get_parser()
     arguments = parser.parse_args(args=None if sys.argv[0:] else ['--help'])
+    suffix = arguments.o
 
     # According to command line instructions, transformations are applied on
     # copies of selected subject images
     if arguments.h is None:
+
         # transformations are applied for each selected subject
-            for fname in arguments.i:
-                fname_path = os.path.abspath(fname)
-                if fname_path:
-                    main(fname_path, arguments.o)
+        for fname in arguments.i:
+            fname_path = os.path.abspath(fname)
+            if fname_path:
+                """Main function, crop and save image"""
+                name = os.path.basename(fname_path).split(fname_path)[0]
+                # get file path
+                path = os.path.join(os.getcwd(), fname_path)
+                # create new path to save data
+                path_tf = os.path.join(path, path.split('.nii.gz')[0]+str(suffix)+'.nii.gz')
+                print(path_tf)
+                if os.path.isfile(path_tf):
+                    os.remove(path_tf)
+                # load image
+                print(fname_path)
+                img = nib.load(fname_path)
+                print('\n----------affine transformation subject: '+name+'------------')
+                angle_IS, angle_PA, angle_LR, shift_LR, shift_PA, shift_IS = random_values()
+                # nibabel data follows the RAS+ (Right, Anterior, Superior are in the ascending direction) convention,
+                data, min_pad = get_image(img, angle_IS, angle_PA, angle_LR, shift_LR, shift_PA, shift_IS)
+                data_shift_rot = transfo(angle_IS, angle_PA, angle_LR, shift_LR, shift_PA, shift_IS, data)
+                # load data back to nifti format
+                img_t = nib.Nifti1Image(data_shift_rot, img.affine)
+                print('new image shape: ',img_t.shape)
+                print('new image path: '+path_tf)
+                img_t.to_filename(path_tf)
                 # raise output error if the subject does not exist
-                else:
-                    print('error: '+subject+' is not a valid subject')
+            else:
+                print('error: '+fname_path+' is not a valid subject')
     else:
         parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/affine_transfo.py
+++ b/affine_transfo.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8
 #########################################################################################
 #
-# implement random transformations to mimic subject repositioning, for each rescaling,
+# implement random transformations to mimic subject repositioning, for each subject,
 #
 # generate randomized transfo per subject, and freeze them in the repos,
 # so that we can reproduce the results by inputting the frozen params in subsequent runs of the pipeline,

--- a/process_data.sh
+++ b/process_data.sh
@@ -27,7 +27,7 @@ trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT
 # Retrieve input params
 SUBJECT=$1
 # set n_transfo to the desired number of transformed images of same subject to be segmented
-n_transfo=3
+n_transfo=10
 
 
 
@@ -99,10 +99,10 @@ for r_coef in ${R_COEFS[@]}; do
   seq_transfo=$(seq ${n_transfo})
   for i_transfo in ${seq_transfo[@]}; do
     # Image homothetic rescaling
-    affine_rescale -i ${SUBJECT}_T2w.nii.gz -r ${r_coef}
-    affine_transfo -i ${SUBJECT}_T2w_r${r_coef}.nii.gz -o _t${i_transfo} -o_file $PATH_RESULTS/transfo_values.csv
+    affine_transfo -i ${SUBJECT}_T2w.nii.gz -o _t${i_transfo}
+    affine_rescale -i ${SUBJECT}_T2w_t${i_transfo}.nii.gz -r ${r_coef}
     # sct_resample -i ${SUBJECT}_T2w.nii.gz -o ${SUBJECT}_T2w_r${r_coef}.nii.gz -f ${r_coef}x${r_coef}x${r_coef}
-    file_t2=${SUBJECT}_T2w_r${r_coef}_t${i_transfo}
+    file_t2=${SUBJECT}_T2w_t${i_transfo}_r${r_coef}
     # Segment spinal cord (only if it does not exist)
     segment_if_does_not_exist $file_t2 "t2"
     # name segmented file

--- a/process_data.sh
+++ b/process_data.sh
@@ -99,8 +99,8 @@ for r_coef in ${R_COEFS[@]}; do
   seq_transfo=$(seq ${n_transfo})
   for i_transfo in ${seq_transfo[@]}; do
     # Image homothetic rescaling
-    python ../../../affine_transfo.py -i ${SUBJECT}_T2w.nii.gz -o _t${i_transfo}
-    python ../../../affine_rescale.py -i ${SUBJECT}_T2w_t${i_transfo}.nii.gz -r ${r_coef}
+    affine_transfo -i ${SUBJECT}_T2w.nii.gz -o _t${i_transfo}
+    affine_rescale -i ${SUBJECT}_T2w_t${i_transfo}.nii.gz -r ${r_coef}
     # sct_resample -i ${SUBJECT}_T2w.nii.gz -o ${SUBJECT}_T2w_r${r_coef}.nii.gz -f ${r_coef}x${r_coef}x${r_coef}
     file_t2=${SUBJECT}_T2w_t${i_transfo}_r${r_coef}
     # Segment spinal cord (only if it does not exist)

--- a/process_data.sh
+++ b/process_data.sh
@@ -27,7 +27,7 @@ trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT
 # Retrieve input params
 SUBJECT=$1
 # set n_transfo to the desired number of transformed images of same subject to be segmented
-n_transfo=10
+n_transfo=3
 
 
 
@@ -99,10 +99,10 @@ for r_coef in ${R_COEFS[@]}; do
   seq_transfo=$(seq ${n_transfo})
   for i_transfo in ${seq_transfo[@]}; do
     # Image homothetic rescaling
-    affine_transfo -i ${SUBJECT}_T2w.nii.gz -o _t${i_transfo}
-    affine_rescale -i ${SUBJECT}_T2w_t${i_transfo}.nii.gz -r ${r_coef}
+    affine_rescale -i ${SUBJECT}_T2w.nii.gz -r ${r_coef}
+    affine_transfo -i ${SUBJECT}_T2w_r${r_coef}.nii.gz -o _t${i_transfo} -o_file $PATH_RESULTS/transfo_values.csv
     # sct_resample -i ${SUBJECT}_T2w.nii.gz -o ${SUBJECT}_T2w_r${r_coef}.nii.gz -f ${r_coef}x${r_coef}x${r_coef}
-    file_t2=${SUBJECT}_T2w_t${i_transfo}_r${r_coef}
+    file_t2=${SUBJECT}_T2w_r${r_coef}_t${i_transfo}
     # Segment spinal cord (only if it does not exist)
     segment_if_does_not_exist $file_t2 "t2"
     # name segmented file

--- a/process_data.sh
+++ b/process_data.sh
@@ -97,12 +97,10 @@ for r_coef in ${R_COEFS[@]}; do
   cd anat_r${r_coef}
 
   seq_transfo=$(seq ${n_transfo})
-  echo $@
-  echo $seq_transfo
   for i_transfo in ${seq_transfo[@]}; do
     # Image homothetic rescaling
-    python3 affine_transfo.py -i ${SUBJECT}_T2w.nii.gz -o _t${i_transfo}
-    python3 affine_rescale.py -i ${SUBJECT}_T2w_t${i_transfo}.nii.gz -r ${r_coef}
+    python ../../../affine_transfo.py -i ${SUBJECT}_T2w.nii.gz -o _t${i_transfo}
+    python ../../../affine_rescale.py -i ${SUBJECT}_T2w_t${i_transfo}.nii.gz -r ${r_coef}
     # sct_resample -i ${SUBJECT}_T2w.nii.gz -o ${SUBJECT}_T2w_r${r_coef}.nii.gz -f ${r_coef}x${r_coef}x${r_coef}
     file_t2=${SUBJECT}_T2w_t${i_transfo}_r${r_coef}
     # Segment spinal cord (only if it does not exist)

--- a/process_data.sh
+++ b/process_data.sh
@@ -94,13 +94,16 @@ for r_coef in ${R_COEFS[@]}; do
   cd anat_r${r_coef}
   # set n_transfo sequence to the desired number of transformed images
   # of same subject to be segmented
-  n_transfo=$(seq 10)
-  for j in ${n_transfo[@]}; do
+  n_transfo=$2
+  seq_transfo=$(seq ${n_transfo})
+  echo $@
+  echo $seq_transfo
+  for i_transfo in ${seq_transfo[@]}; do
     # Image homothetic rescaling
-    python ../../../affine_transfo.py -i ${SUBJECT}_T2w.nii.gz -o _t${j}
-    python ../../../affine_rescale.py -i ${SUBJECT}_T2w_t${j}.nii.gz -r ${r_coef}
+    python ../../../affine_transfo.py -i ${SUBJECT}_T2w.nii.gz -o _t${i_transfo}
+    python ../../../affine_rescale.py -i ${SUBJECT}_T2w_t${i_transfo}.nii.gz -r ${r_coef}
     # sct_resample -i ${SUBJECT}_T2w.nii.gz -o ${SUBJECT}_T2w_r${r_coef}.nii.gz -f ${r_coef}x${r_coef}x${r_coef}
-    file_t2=${SUBJECT}_T2w_t${j}_r${r_coef}
+    file_t2=${SUBJECT}_T2w_t${i_transfo}_r${r_coef}
     # Segment spinal cord (only if it does not exist)
     segment_if_does_not_exist $file_t2 "t2"
     # name segmented file
@@ -110,10 +113,10 @@ for r_coef in ${R_COEFS[@]}; do
     file_label=$FILELABEL
     # Compute average CSA between C2 and C5 levels (append across subjects)
     # sct_process_segmentation -i $file_t2_seg.nii.gz -vert 1:3 -vertfile ${file_t2_seg}_labeled.nii.gz -o $PATH_RESULTS/csa_${SUBJECT}_${r_coef}.csv -qc ${PATH_QC}
-    sct_process_segmentation -i $file_t2_seg.nii.gz -vert 2:5 -perlevel 1 -vertfile ${file_t2_seg}_labeled.nii.gz -o $PATH_RESULTS/csa_perlevel_${SUBJECT}_t${j}_${r_coef}.csv -qc ${PATH_QC}
+    sct_process_segmentation -i $file_t2_seg.nii.gz -vert 2:5 -perlevel 1 -vertfile ${file_t2_seg}_labeled.nii.gz -o $PATH_RESULTS/csa_perlevel_${SUBJECT}_t${i_transfo}_${r_coef}.csv -qc ${PATH_QC}
     # add files to check
     FILES_TO_CHECK+=(
-    "$PATH_RESULTS/csa_perlevel_${SUBJECT}_t${j}_${r_coef}.csv"
+    "$PATH_RESULTS/csa_perlevel_${SUBJECT}_t${i_transfo}_${r_coef}.csv"
     "$PATH_RESULTS/${SUBJECT}/anat_r${r_coef}/${file_t2_seg}.nii.gz"
     )
   done

--- a/process_data.sh
+++ b/process_data.sh
@@ -23,9 +23,12 @@ set -e
 # Exit if user presses CTRL+C (Linux) or CMD+C (OSX)
 trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT
 
+# Global variables
 # Retrieve input params
 SUBJECT=$1
-#FILEPARAM=$2
+# set n_transfo to the desired number of transformed images of same subject to be segmented
+n_transfo=10
+
 
 
 # FUNCTIONS
@@ -92,16 +95,14 @@ for r_coef in ${R_COEFS[@]}; do
   # rename anat to explicit resampling coefficient
   mv anat anat_r$r_coef
   cd anat_r${r_coef}
-  # set n_transfo sequence to the desired number of transformed images
-  # of same subject to be segmented
-  n_transfo=$2
+
   seq_transfo=$(seq ${n_transfo})
   echo $@
   echo $seq_transfo
   for i_transfo in ${seq_transfo[@]}; do
     # Image homothetic rescaling
-    python ../../../affine_transfo.py -i ${SUBJECT}_T2w.nii.gz -o _t${i_transfo}
-    python ../../../affine_rescale.py -i ${SUBJECT}_T2w_t${i_transfo}.nii.gz -r ${r_coef}
+    python3 affine_transfo.py -i ${SUBJECT}_T2w.nii.gz -o _t${i_transfo}
+    python3 affine_rescale.py -i ${SUBJECT}_T2w_t${i_transfo}.nii.gz -r ${r_coef}
     # sct_resample -i ${SUBJECT}_T2w.nii.gz -o ${SUBJECT}_T2w_r${r_coef}.nii.gz -f ${r_coef}x${r_coef}x${r_coef}
     file_t2=${SUBJECT}_T2w_t${i_transfo}_r${r_coef}
     # Segment spinal cord (only if it does not exist)

--- a/process_data.sh
+++ b/process_data.sh
@@ -83,7 +83,7 @@ R_COEFS=(0.90 0.95 1)
 for r_coef in ${R_COEFS[@]}; do
   if [ -d "anat_r${r_coef}" ]; then
    rm -r "anat_r${r_coef}"
-   echo "anat_r${r_coef} allready exists: creating folder"
+   echo "anat_r${r_coef} already exists: creating folder"
  fi
  if [ -f "$PATH_RESULTS/csa_perlevel_${SUBJECT}_${r_coef}.csv" ]; then
    rm "$PATH_RESULTS/csa_perlevel_${SUBJECT}_${r_coef}.csv"
@@ -92,7 +92,10 @@ for r_coef in ${R_COEFS[@]}; do
   # rename anat to explicit resampling coefficient
   mv anat anat_r$r_coef
   cd anat_r${r_coef}
-  for j in 0 1 2; do
+  # set n_transfo sequence to the desired number of transformed images
+  # of same subject to be segmented
+  n_transfo=$(seq 10)
+  for j in ${n_transfo[@]}; do
     # Image homothetic rescaling
     python ../../../affine_transfo.py -i ${SUBJECT}_T2w.nii.gz -o _t${j}
     python ../../../affine_rescale.py -i ${SUBJECT}_T2w_t${j}.nii.gz -r ${r_coef}

--- a/process_data.sh
+++ b/process_data.sh
@@ -99,10 +99,10 @@ for r_coef in ${R_COEFS[@]}; do
   seq_transfo=$(seq ${n_transfo})
   for i_transfo in ${seq_transfo[@]}; do
     # Image homothetic rescaling
-    affine_transfo -i ${SUBJECT}_T2w.nii.gz -o _t${i_transfo}
-    affine_rescale -i ${SUBJECT}_T2w_t${i_transfo}.nii.gz -r ${r_coef}
-    # sct_resample -i ${SUBJECT}_T2w.nii.gz -o ${SUBJECT}_T2w_r${r_coef}.nii.gz -f ${r_coef}x${r_coef}x${r_coef}
-    file_t2=${SUBJECT}_T2w_t${i_transfo}_r${r_coef}
+    affine_rescale -i ${SUBJECT}_T2w.nii.gz -r ${r_coef}
+    affine_transfo -i ${SUBJECT}_T2w_r${r_coef}.nii.gz -o _t${i_transfo} -o_file $PATH_RESULTS/transfo_values.csv
+
+    file_t2=${SUBJECT}_T2w_r${r_coef}_t${i_transfo}
     # Segment spinal cord (only if it does not exist)
     segment_if_does_not_exist $file_t2 "t2"
     # name segmented file


### PR DESCRIPTION
Up to now transformations are cumulated, which adds unnecessary interpolation errors. The use of "skimage.transformation rotate" implicitly applied warp function slice/slice which led to difficulties when the rotation was not around the normal vector to the slice. 

The new function affine_transform from scipy.ndimage uses an inverse process. 
1. Create new empty volume K identical to padded input image (J) and apply transformation on K,
2. Shift J voxels by difference of center coordinates. This allows overlap of J center and K center,
3. Resample J according to K,

Error of CSA on 1 subject is 0.5 mm² much better than the 2.7 mm² of precedent method. Maybe a look into the precision of the rotation matrix could  minimize error.

DONE:
- Use of new function "affine_transform"
- Generalize use of right hand rule for angle rotations

FIX #18 

 