### PR TITLE
package csa-atrophy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ Dataset/
             └── sub-subj01_T2w.json
      └── sub-subj02
          └── anat
-         └── sub-subj02_T2w.nii.gz
-         └── sub-subj02_T2w.json
+            └── sub-subj02_T2w.nii.gz
+            └── sub-subj02_T2w.json
  └── results
 
 ~~~
 # Installation
 csa-atrophy requires specific python packages for computing statistics and processing images. If not already present on the computers python environment such packages will automatically be installed by running pip command:
 ~~~
-pip install -r requirements.txt
+pip install -e .
 ~~~
 # How to run
 Download (or git clone) this repository:
@@ -33,7 +33,7 @@ cd csa-atrophy
 Fetch dataset (2 choices):
   - To fetch/sync dataset run command: (this file should be edited according to your needs)
   ~~~
-  ./csa-fetch-dataset.sh
+  ./csa_fetch_dataset.sh
   ~~~
   - To fetch specific version of openneuro repository (version: 1.0.5, Files: 2501, Size: 7.9GB, Subjects: 248) follow instructions to set openeuro CLI: https://www.npmjs.com/package/openneuro-cli
   ~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ scipy
 matplotlib
 scikit-image
 nibabel
-maths
 glob

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ scipy
 matplotlib
 scikit-image
 nibabel
-glob

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
     install_requires=install_reqs,
     entry_points={
         'console_scripts': [
-            'affine_transfo = affine_transfo:main'
-            'affine_rescale = affine_rescale:main'
+            'affine_transfo=affine_transfo:main',
+            'affine_rescale=affine_rescale:main'
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+from setuptools import setup, find_packages
+from codecs import open
+from os import path
+
+
+# Get the directory where this current file is saved
+here = path.abspath(path.dirname(__file__))
+
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+req_path = path.join(here, 'requirements.txt')
+with open(req_path, "r") as f:
+    install_reqs = f.read().strip()
+    install_reqs = install_reqs.split("\n")
+
+setup(
+    name='csa-atrophy',
+    version='0.1.0',
+    python_requires='>=3.6',
+    description='Evaluate the sensitivity of atrophy detection with SCT.',
+    author='NeuroPoly Lab, Polytechnique Montreal',
+    author_email='neuropoly@googlegroups.com',
+    license='MIT',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.7',
+    ],
+    keywords='',
+    install_requires=install_reqs,
+    entry_points={
+        'console_scripts': [
+            'affine_transfo = affine_transfo:main'
+            'affine_rescale = affine_rescale:main'
+        ],
+    },
+)


### PR DESCRIPTION
Create a python package out of the codebase (setuptools), with a setup.py file, and entrypoints to scripts so it is possible to call them from any directory.
The setup.py file also manages requirements as in: https://github.com/sct-pipeline/spine-generic/blob/master/setup.py

For the moment: I am trying to run `pip install -e .` but error `Could not find a version that satisfies the requirement glob (from csa-atrophy==0.1.0) (from versions: none) ` is displayed

DONE:
- create setup.py

Fix #20 