### PR TITLE
large dataset computing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Fetch dataset (2 choices):
   ~~~
 Run the following script within the Dataset folder to extract CSA. This script can be run on desired subjects using flag -include and in parallel processing using flag -jobs.
 ~~~
-sct_run_batch -path-data data -path-output csa_atrophy_results process_data.sh
+sct_run_batch -config config_sct_run_batch.yml
 ~~~
 To output statistics, run in Dataset
 ~~~
-python csa_rescale_stat.py -i csa_atrophy_results/results/csa_data -o csa_atrophy_results -v
+python csa_rescale_stat.py -i csa_atrophy_results/results/csa_data -o csa_atrophy_results -config config_script.yml -v
 ~~~
 
 # Quality Control
@@ -57,5 +57,5 @@ After running the analysis, check your Quality Control (QC) report by opening th
 The bash script outputs all effectuated manual labelings to 'results_corrected/seg_manual'.
 It is now possible to re-run the whole process, pointing to the manual corrections. With the command below labeling will use the manual corrections present in 'seg_manual', otherwise labeling will be done automatically.
 ~~~
-sct_run_batch -path-data data -path-output csa_atrophy_results_corrected -path-segmanual seg_manual process_data.sh
+sct_run_batch -config config_sct_run_batch.yml
 ~~~

--- a/affine_rescale.py
+++ b/affine_rescale.py
@@ -49,7 +49,7 @@ def get_parser():
 ############################################################
 def main():
     """Main function, isotropic rescale of input images according to coef_r"""
-    
+
     # get parser elements
     parser = get_parser()
     arguments = parser.parse_args(args=None if sys.argv[0:] else ['--help'])
@@ -57,6 +57,9 @@ def main():
     fname = arguments.i
     # coef_r is image rescaling coefficient
     coef_r = arguments.r
+    name_coef = arguments.r
+    if coef_r == "gt":
+        coef_r = 1
 
     # load image
     img = nib.load(fname)
@@ -65,7 +68,7 @@ def main():
     img_t = nib.Nifti1Image(data, img.affine) # change affine for data
 
     # save rescaled image
-    fname_out = fname.split('.nii.gz')[0] + '_r'+str(coef_r)+'.nii.gz'
+    fname_out = fname.split('.nii.gz')[0] + '_r'+str(name_coef)+'.nii.gz'
     nib.save(img_t, fname_out)
 
 #RUN

--- a/config_script.yml
+++ b/config_script.yml
@@ -3,8 +3,9 @@
 # process_data.sh parameters
 n_transfo: 2
 rescaling:
-  - 0.95
-  - 1.00
+  #- 0.95
+  #- 1.00
+  - "gt"
 contrast: "t2"
 
 # manual_labeling_correction.sh parameters
@@ -28,7 +29,7 @@ transfo:
   bounds:
     angle_bound: 5
     shift_bound: 2.5
-    
+
 # config file for sct_run_batch
 path_data   : "data"
 path_output : "csa_atrophy_results_t2"

--- a/config_sct_run_batch.yml
+++ b/config_sct_run_batch.yml
@@ -1,0 +1,22 @@
+# config file for sct_run_batch
+path_data: data
+path_output: csa_atrophy_results
+path_segmanual: data/derivatives/labels
+script: process_data.sh
+
+
+jobs        : -1
+batch_log: sct_run_batch_log.txt
+config: null
+continue_on_error: 1
+email_from: null
+email_host: smtp.gmail.com:587
+email_to: null
+exclude: null
+exclude_list: null
+include: null
+include_list: null
+itk_threads: 1
+script_args: ''
+subject_prefix: sub-
+zip: false

--- a/csa_rescale_stat.py
+++ b/csa_rescale_stat.py
@@ -85,11 +85,13 @@ def plot_perc_err(df, columns_to_plot, path_output):
     :param columns_to_plot: perc_diff dataframe columns for plotting
     :param path_output: directory in which plot is saved
     """
+    df = df.reset_index().set_index('Rescale')
+    df['subject'] = list(tf.split('_T2w')[0] for tf in df['Filename'])
     fig, axes = plt.subplots(nrows=2, ncols=1, figsize=(8, 6))
     df.groupby('Rescale')[columns_to_plot].mean().plot(kind='bar', ax=axes[0], grid=True)
     axes[0].set_title('mean error function of rescaling factor')
     axes[0].set_ylabel('error in %')
-    df.groupby('Rescale')[columns_to_plot].std().plot(kind='bar', ax=axes[1], sharex=True, sharey=True, legend=False)
+    df.groupby(['Rescale', 'subject']).mean().groupby('Rescale').std()[columns_to_plot].plot(kind='bar', ax=axes[1], sharex=True, sharey=True, legend=False)
     axes[1].set_title('STD of error function of rescaling factor')
     plt.xlabel('rescaling factor')
     plt.ylabel('error in %')

--- a/process_data.sh
+++ b/process_data.sh
@@ -25,18 +25,18 @@ SUBJECT=$1
 # The following global variables are retrieved from config.yaml file
 # set n_transfo to the desired number of transformed images of same subject for segmentation,
 # n_transfo also represents the number of iterations of the transformation, segmentation and labeling process
-n_transfo=$(yaml_parser -o n_transfo)
+n_transfo=$(yaml_parser -o n_transfo -i config_script.yml)
 # define rescaling coefficients (always keep value 1 for reference)
-rescaling=$(yaml_parser -o rescaling)
+rescaling=$(yaml_parser -o rescaling -i config_script.yml)
 R_COEFS=$(echo $rescaling | tr '[]' ' ' | tr ',' ' ' | tr "'" ' ')
-contrast=$(yaml_parser -o contrast)
+contrast=$(yaml_parser -o contrast -i config_script.yml)
 if [ $contrast == "t2" ]; then
   contrast_str="T2w"
 fi
 if [ $contrast == "t1" ]; then
   contrast_str="T1w"
 fi
-path_output=$(yaml_parser -o path_output)
+path_output=$(yaml_parser -o path_output -i config_sct_run_batch.yml)
 
 
 # FUNCTIONS
@@ -47,7 +47,10 @@ label_if_does_not_exist(){
   local file="$1"
   local file_seg="$2"
   local scale="$3"
-
+  if [ $scale == "gt" ]; then
+    local scale=1.0
+  fi
+  echo $scale
   # Update global variable with segmentation file name
   FILELABEL="${file}_labels"
   if [ -e "../../../${PATH_SEGMANUAL}/${file}_labels-manual.nii.gz" ]; then


### PR DESCRIPTION
For csa-atrophy pipeline to be able to compute large datasets, parallel processing must be put in place. Parallel processing is possible on several subjects (I think this is sufficient) but not on several transformations or rescalings. 
Computing CSA on a 200 subject dataset (and 200 cores) augmented with x50 transformations and x 5 (0.85, 0.90, 0.95, 0,97, 0.99, 1) rescalings, should take (250 segmentation of 30sec = 125min) over 2h. 

I am not sure how long the segmentation will take but it would be good to use already labeled images. Are these available under spine generic?

Discussed in last meeting: for rescale=1 the perc_diff=0. @jcohenadad could you remind me why we thought this was not a normal behavior. If same subject with rescale=1 is segmented twice same CSA value would be measured? 

DONE:
- Mean (across subjects, rescalings and vertebrae levels) STD of intra-subject CSA