### PR TITLE
Correct run_all.py log file path

### DIFF
--- a/run_all.py
+++ b/run_all.py
@@ -62,6 +62,10 @@ def main():
     arguments = parser.parse_args()
     config_file = os.path.abspath(os.path.expanduser(arguments.config))
     config_param = yaml_parser(config_file)
+
+    # get path for log file
+    dir_output = config_param['path_output']
+    path_output = os.path.abspath(os.path.expanduser(dir_output))
     # Get list of subjects in path data
     dir_data = config_param['path_data']
     path_data = os.path.abspath(os.path.expanduser(dir_data))
@@ -77,8 +81,8 @@ def main():
     for sublist in sublists:
         i = i + 1
         # Create temporary job shell script, default: job_csa_sublist_i.sh
-        filename = os.path.abspath(os.path.expanduser(arguments.o_shell)) + str(i) + ".sh"
-        log_filename = os.path.join(os.path.dirname(filename), "log_" + os.path.basename(filename).split(".")[0] + ".txt")
+        filename = os.path.abspath(os.path.expanduser('tmp.job_csa_sublist_')) + str(i) + ".sh"
+        log_filename = os.path.join(path_output, "log", "log_" + os.path.basename(filename).split(".")[1] + ".txt")
         # create shell script for sbatch
         with open(filename, 'w+') as temp_file:
             # bash content

--- a/run_all.py
+++ b/run_all.py
@@ -81,7 +81,7 @@ def main():
     for sublist in sublists:
         i = i + 1
         # Create temporary job shell script, default: job_csa_sublist_i.sh
-        filename = os.path.abspath(os.path.expanduser('tmp.job_csa_sublist_')) + str(i) + ".sh"
+        filename = os.path.abspath(os.path.expanduser(arguments.o_shell)) + str(i) + ".sh"
         log_filename = os.path.join(path_output, "log", "log_" + os.path.basename(filename).split(".")[1] + ".txt")
         # create shell script for sbatch
         with open(filename, 'w+') as temp_file:


### PR DESCRIPTION
When running batches via run_all the log files are output in the current folder. As mentioned in #62 a better practice would be to place log file under output_path/log/ as was the case before.

DONE:
- place log file in output_path/log/

FIXES #62 