### PR TITLE
Crop labeled images in process_data.sh

### DIFF
--- a/process_data.sh
+++ b/process_data.sh
@@ -149,12 +149,16 @@ echo "+++++++++++ TIME: Duration of labelling:    $(($runtime / 3600))hrs $((($r
 
 # dilate segmentation (for cropping)
 sct_maths -i ${file_seg}.nii.gz -dilate 15 -shape cube -o ${file_seg}_dil.nii.gz
+file_seg_dil=${file_seg}_dil
 # crop image
-sct_crop_image -i ${file}.nii.gz -m ${file_seg}_dil.nii.gz
+sct_crop_image -i ${file}.nii.gz -m ${file_seg_dil}.nii.gz
 file=${file}_crop
 # crop segmentation
-sct_crop_image -i ${file_seg}.nii.gz -m ${file_seg}_dil.nii.gz
+sct_crop_image -i ${file_seg}.nii.gz -m ${file_seg_dil}.nii.gz
 file_seg=${file_seg}_crop
+# crop segmentation
+sct_crop_image -i ${file_label}.nii.gz -m ${file_seg_dil}.nii.gz
+file_label=${file_label}_crop
 cd ../
 
 
@@ -177,7 +181,7 @@ for r_coef in ${R_COEFS[@]}; do
   file_r=${file}_r${r_coef}
   affine_rescale -i ../anat/${file}.nii.gz -r ${r_coef} -o ${file_r}.nii.gz
   # rescale labeled segmentation
-  file_label_r=${file_r}_seg_labeled
+  file_label_r=${file_label}_r${r_coef}
   affine_rescale -i ../anat/${file_label}.nii.gz -r ${r_coef} -o ${file_label_r}.nii.gz
 
   # create list of array to iterate on (e.g.: seq_transfo = 1 2 3 4 5 if n_transfo=5)


### PR DESCRIPTION
Up to now images containing manual labels are not cropped (segmented and labeled images do not have the same space). This is probably causing the sct_process_segmentation errors in commit ee367a4.

DONE:
- Add cropping on labeled images
- Verify filename convention (adding suffix in order of process). Example: `sub-amu02_T2w_RPI_r_seg_labeled_crop_r1_t2.nii.gz`

Fixes #66 