### PR TITLE
Correction: run_all does not use OpenMP

### DIFF
--- a/run_all.py
+++ b/run_all.py
@@ -30,7 +30,7 @@ def get_parser(mandatory=None):
              #SBATCH --account=def-jcohen
              #SBATCH --time=0-08:00        # time (DD-HH:MM)
              #SBATCH --nodes=1
-             #SBATCH --cpus-per-task=32
+             #SBATCH --cpus-per-task=32    # number of OpenMP processes
              #SBATCH --mem=128G
              cd $SCRATCH""",
     )
@@ -74,7 +74,7 @@ def main():
         job_template = """#SBATCH --account=def-jcohen
 #SBATCH --time=0-08:00        # time (DD-HH:MM)
 #SBATCH --nodes=1
-#SBATCH --cpus-per-task=32
+#SBATCH --cpus-per-task=32    # number of OpenMP processes
 #SBATCH --mem=128G
 """
 

--- a/run_all.py
+++ b/run_all.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8
 #########################################################################################
 #
-# Break down OpenMP jobs across sub-datasets
+# Break down multiprocessing jobs across sub-datasets
 # example: python run_all.py -config config_sct_run_batch.yml
 #
 #########################################################################################
@@ -15,7 +15,7 @@ import yaml
 def get_parser(mandatory=None):
     """parser function"""
     parser = argparse.ArgumentParser(
-        description="Break down OpenMP jobs across sub-datasets",
+        description="Break down multiprocessing jobs across sub-datasets",
         formatter_class=argparse.RawTextHelpFormatter,
         prog=os.path.basename(__file__).strip(".py")
     )
@@ -30,13 +30,13 @@ def get_parser(mandatory=None):
              #SBATCH --account=def-jcohen
              #SBATCH --time=0-08:00        # time (DD-HH:MM)
              #SBATCH --nodes=1
-             #SBATCH --cpus-per-task=32    # number of OpenMP processes
+             #SBATCH --cpus-per-task=32
              #SBATCH --mem=128G
              cd $SCRATCH""",
     )
     parser.add_argument(
         '-n',
-        help="Break down OpenMP jobs across sub-datasets of n subjects. Adjust 'n' based on the number of CPU cores "
+        help="Break down multiprocessing jobs across sub-datasets of n subjects. Adjust 'n' based on the number of CPU cores "
              "available",
         type=int,
         default=32
@@ -74,7 +74,7 @@ def main():
         job_template = """#SBATCH --account=def-jcohen
 #SBATCH --time=0-08:00        # time (DD-HH:MM)
 #SBATCH --nodes=1
-#SBATCH --cpus-per-task=32    # number of OpenMP processes
+#SBATCH --cpus-per-task=32
 #SBATCH --mem=128G
 """
 


### PR DESCRIPTION
Up to now the help for run_all says "Break down OpenMP jobs across sub-datasets" but this is not the case. `run_all` batches jobs and uses local multiprocessing on a single node without using openmp. 

DONE:
- change the term openMP for the term multiprocessing. Example: `Break down OpenMP jobs across sub-datasets` becomes `Break down multiprocessing jobs across sub-datasets`.

Fixes #68 