### PR TITLE
Set number of threads used in processing

### DIFF
--- a/job_template.sh
+++ b/job_template.sh
@@ -5,5 +5,7 @@
 #SBATCH --mem=128G
 #SBATCH --mail-user=paul.bautin@polymtl.ca
 #SBATCH --mail-type=ALL
+export OMP_NUM_THREADS=1
+export MKL_NUM_THREADS=1
 
 cd $SCRATCH


### PR DESCRIPTION
I recently tried to launch a new processing with commit: https://github.com/sct-pipeline/csa-atrophy/commit/64d99c1f3cddec9f1a75da2df2ece6209bf2b09e. After a few minutes, i received a mail from Compute Canada entitled "Too Many Threads for Graham Jobs". It explained that the "submitted jobs asked for 32 CPU cores but it was starting many more threads than that".

The proposed (and implemented) solution is to add in job_template.sh after any #SBATCH commands and module loads the following lines:
export OMP_NUM_THREADS=1
export MKL_NUM_THREADS=1

Fixes #76 

