### PR TITLE
Update link to data-multi-subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ csa-atrophy requires specific python packages for computing statistics and proce
 pip install -e .
 ~~~
 
-Download the [Spine Generic Multi-Subject dataset](https://github.com/spine-generic/data-multi-subject#download). 
+Download the [Spine Generic Multi-Subject dataset](https://github.com/spine-generic/data-multi-subject#download). To access specific repository tag use command:
+~~~
+git clone -b r20200907 https://github.com/spine-generic/data-multi-subject
+~~~
 
 Edit the file `config_sct_run_batch.yml` according to your setup. Notable flags include:
 - `path_data`: If you downloaded the spine-generic data at another location, make sure to update the path;


### PR DESCRIPTION
Up to now user was redirected towards most recent version of data-multi-subject repository. I have added a comment in the README specifying how to clone a specific repository tag. 
I am still investigating if command `git annex get` will not automatically retrieve latest version.

Fixes #41 