### PR TITLE
Resample images to desired resolution

### DIFF
--- a/config_script.yml
+++ b/config_script.yml
@@ -17,7 +17,7 @@ rescaling:
 
 # Contrasts on which to perform the analysis. Available values are: 't1', 't2'
 contrast: "t2"
-# image resolution (generally T1w images have resolution 1mm isotropic and T2w images 0.8mm isotropic)
+# Resampling resolution in mm. Native resolutions for the spine-generic project are 1mm isotropic for T1w images and 0.8mm isotropic for T2w images. 
 interp_t1: "1x1x1"
 interp_t2: "0.8x0.8x0.8"
 

--- a/config_script.yml
+++ b/config_script.yml
@@ -14,8 +14,12 @@ rescaling:
   - 0.95
   - 0.94
   - 0.93
+
 # Contrasts on which to perform the analysis. Available values are: 't1', 't2'
 contrast: "t2"
+# image resolution (generally T1w images have resolution 1mm isotropic and T2w images 0.8mm isotropic)
+interp_t1: "1x1x1"
+interp_t2: "0.8x0.8x0.8"
 
 # csa_atrophy_stat.py
 # -------------------

--- a/config_sct_run_batch.yml
+++ b/config_sct_run_batch.yml
@@ -2,7 +2,7 @@
 path_data: /scratch/pabaua/data-multi-subject-p
 path_output: /scratch/pabaua/results_csa_t2
 script: /home/pabaua/csa-atrophy/process_data.sh
-script_args: /home/pabaua/csa-atrophy/config_script_t2.yml
+script_args: /home/pabaua/csa-atrophy/config_script.yml
 jobs: -1
 batch_log: sct_run_batch_log.txt
 continue_on_error: 1

--- a/config_sct_run_batch.yml
+++ b/config_sct_run_batch.yml
@@ -1,6 +1,6 @@
 # config file for sct_run_batch
 path_data: /scratch/pabaua/data-multi-subject-p
-path_output: /scratch/pabaua/results_csa_t2_2
+path_output: /scratch/pabaua/results_csa_t2_3
 script: /home/pabaua/csa-atrophy/process_data.sh
 script_args: /home/pabaua/csa-atrophy/config_script_t2.yml
 jobs: -1

--- a/config_sct_run_batch.yml
+++ b/config_sct_run_batch.yml
@@ -1,6 +1,6 @@
 # config file for sct_run_batch
 path_data: /scratch/pabaua/data-multi-subject-p
-path_output: /scratch/pabaua/results_csa_t2_3
+path_output: /scratch/pabaua/results_csa_t2
 script: /home/pabaua/csa-atrophy/process_data.sh
 script_args: /home/pabaua/csa-atrophy/config_script_t2.yml
 jobs: -1

--- a/process_data.sh
+++ b/process_data.sh
@@ -37,6 +37,8 @@ n_transfo=$(yaml_parser -o n_transfo -i $config_script)
 rescaling=$(yaml_parser -o rescaling -i $config_script)
 R_COEFS=$(echo $rescaling | tr '[]' ' ' | tr ',' ' ' | tr "'" ' ')
 contrast=$(yaml_parser -o contrast -i $config_script)
+interp_t1=$(yaml_parser -o interp_t1 -i $config_script)
+interp_t2=$(yaml_parser -o interp_t2 -i $config_script)
 
 # FUNCTIONS
 # ==============================================================================
@@ -112,12 +114,12 @@ rm -r dwi
 #=======================================================================
 cd anat
 # Reorient to RPI and resample file
-if [ $contrast == "t2" ]; then
-  contrast_str="T2w"
-  interp="1x1x1"
-elif [ $contrast == "t1" ]; then
+if [ $contrast == "t1" ]; then
   contrast_str="T1w"
-  interp="1x1x1"
+  interp=$interp_t1
+elif [ $contrast == "t2" ]; then
+  contrast_str="T2w"
+  interp=$interp_t2
 fi
 file=${SUBJECT}_${contrast_str}
 # Reorient image to RPI

--- a/process_data.sh
+++ b/process_data.sh
@@ -82,10 +82,11 @@ segment_if_does_not_exist(){
   local qc=$3
   # Update global variable with segmentation file name
   FILESEG="${file}_seg"
-  FILESEGMANUAL="${path_derivatives}/${FILESEG}-manual.nii.gz"
+  FILESEGMANUAL="${path_derivatives}/${FILESEG}-manual"
   if [ -e $FILESEGMANUAL ]; then
     echo "Found! Using manual segmentation."
-    rsync -avzh $FILESEGMANUAL ${FILESEG}.nii.gz
+    sct_resample -i ${FILESEGMANUAL}.nii.gz -mm $interp -x nn -o ${FILESEGMANUAL}_r.nii.gz
+    rsync -avzh ${FILESEGMANUAL}.nii.gz ${FILESEG}.nii.gz
     sct_qc -i ${file}.nii.gz -s ${FILESEG}.nii.gz -p sct_deepseg_sc $qc
   else
     # Segment spinal cord

--- a/process_data.sh
+++ b/process_data.sh
@@ -117,7 +117,7 @@ cd anat
 # Reorient to RPI and resample file
 if [ $contrast == "t2" ]; then
   contrast_str="T2w"
-  interp="0.8x0.8x0.8"
+  interp="1x1x1"
 elif [ $contrast == "t1" ]; then
   contrast_str="T1w"
   interp="1x1x1"

--- a/process_data.sh
+++ b/process_data.sh
@@ -82,7 +82,7 @@ segment_if_does_not_exist(){
   if [ -e $FILESEGMANUAL ]; then
     echo "Found! Using manual segmentation."
     sct_resample -i ${FILESEGMANUAL}.nii.gz -mm $interp -x nn -o ${FILESEGMANUAL}_r.nii.gz
-    rsync -avzh ${FILESEGMANUAL}.nii.gz ${FILESEG}.nii.gz
+    rsync -avzh ${FILESEGMANUAL}_r.nii.gz ${FILESEG}.nii.gz
     sct_qc -i ${file}.nii.gz -s ${FILESEG}.nii.gz -p sct_deepseg_sc $qc
   else
     # Segment spinal cord


### PR DESCRIPTION
It was noticed in issue #83 that the CSA of rescaled t1w images was often overestimated. This could be caused by an increasing partial volume effect with tissue outside of the CSF. However, overestimation is less visible in t2w images, this is possibly due to better image resolution (0.8x0.8x0.8mm instead of 1x1x1mm). By resampling the T2w data to 1mm at the very beginning, it would be possible to see if difference between t1w and t2w results is caused by difference of native resolution.

DONE:
- Resample t2w images

FIX #91 