### PR TITLE
Crop around transformed segmentation

### DIFF
--- a/csa_rescale_stat.py
+++ b/csa_rescale_stat.py
@@ -357,7 +357,7 @@ def main():
     df_rescale['std_rescale_estimated'] = df_sub.groupby('rescale').std()['rescale_estimated'].values
     df_rescale['mean_perc_error'] = df_sub.groupby('rescale').mean()['perc_error'].values
     df_rescale['std_perc_error'] = df_sub.groupby('rescale').std()['perc_error'].values
-    #df_rescale['sample_size'] = sample_size(df_rescale, config_param)
+    df_rescale['sample_size'] = sample_size(df_rescale, config_param)
     print(df_rescale)
 
     # plot graph if verbose is present

--- a/csa_rescale_stat.py
+++ b/csa_rescale_stat.py
@@ -294,7 +294,7 @@ def main():
 
     # add useful columns to dataframe
     df_vert['basename'] = list(os.path.basename(path).split('.nii.gz')[0] for path in df_vert['Filename'])
-    df_vert['rescale'] = list(float(b.split('crop_r')[1].split('_')[0]) for b in df_vert['basename'])
+    df_vert['rescale'] = list(float(b.split('RPI_r_r')[1].split('_')[0]) for b in df_vert['basename'])
     df_vert['slices'] = list(int(slices.split(':')[1]) - int(slices.split(':')[0]) + 1 for slices in df_vert['Slice (I->S)'])
 
     # verify if vertlevels of interest were given in input by user
@@ -357,7 +357,7 @@ def main():
     df_rescale['std_rescale_estimated'] = df_sub.groupby('rescale').std()['rescale_estimated'].values
     df_rescale['mean_perc_error'] = df_sub.groupby('rescale').mean()['perc_error'].values
     df_rescale['std_perc_error'] = df_sub.groupby('rescale').std()['perc_error'].values
-    df_rescale['sample_size'] = sample_size(df_rescale, config_param)
+    #df_rescale['sample_size'] = sample_size(df_rescale, config_param)
     print(df_rescale)
 
     # plot graph if verbose is present


### PR DESCRIPTION
This PR aims to implement: https://github.com/sct-pipeline/csa-atrophy/issues/88#issuecomment-716824280. Up to know cropping was performed around a dilated initial segmentation. The new method transforms initial segmentation before cropping image, this ensures spinal cord does not exceed image boundaries.

DONE:
- transform and dilate the labelled segmentation to crop image
- update csa_rescale_stat.py, extract the "rescale" from updated "Filename"

FIX #88 
