### PR TITLE
Increase the dilation used for cropping

### DIFF
--- a/process_data.sh
+++ b/process_data.sh
@@ -185,7 +185,7 @@ for r_coef in ${R_COEFS[@]}; do
 
     # dilate labelled segmentation (for cropping)
     file_label_dil=${file_label_r_t}_dil
-    sct_maths -i ${file_label_r_t}.nii.gz -dilate 15 -shape cube -o ${file_label_dil}.nii.gz
+    sct_maths -i ${file_label_r_t}.nii.gz -dilate 45 -shape cube -o ${file_label_dil}.nii.gz
     # crop image
     sct_crop_image -i ${file_r_t}.nii.gz -m ${file_label_dil}.nii.gz
     file_r_t=${file_r_t}_crop


### PR DESCRIPTION
The problem of bad segmentation (ie that stops in the middle of the FOV) is caused by a failure in the centerline detection. This is likely caused by the FOV being too small (ie: the trained model does not recognize such small FOV). A workaround is to increase the dilation used for cropping setting it to 45. 

It was tested successfully on the problematic subject identified in https://github.com/sct-pipeline/csa-atrophy/issues/93#issuecomment-730462237 

FIX #93 